### PR TITLE
Update turf libs

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,4 +11,3 @@ var changesetParser = R.pipe(
 
 changesetParser.elementParser = elementParser;
 module.exports = changesetParser;
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,34 +1,38 @@
 {
   "name": "real-changesets-parser",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@turf/bbox": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-3.14.0.tgz",
-      "integrity": "sha1-zuXzlt3nisqc7eBeESLbGLxQRjU=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.0.1.tgz",
+      "integrity": "sha512-EGgaRLettBG25Iyx7VyUINsPpVj1x3nFQFiGS3ER8KCI1MximzNLsam3eXRabqQDjyAKyAE1bJ4EZEpGvspQxw==",
       "requires": {
-        "@turf/meta": "^3.14.0"
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x"
       }
     },
     "@turf/bbox-polygon": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-3.14.0.tgz",
-      "integrity": "sha1-0ASwRT8IDo9PV19h3JNjIMVldHo=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-6.0.1.tgz",
+      "integrity": "sha512-f6BK6GOzUNjmJeOYHklk/5LNcQMQbo51gvAM10dTM5IqzKP01KM5bgV88uOKfSZB0HRQVpaRV1tgXk2bg5cPRg==",
       "requires": {
-        "@turf/helpers": "^3.13.0"
+        "@turf/helpers": "6.x"
       }
     },
     "@turf/helpers": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-3.13.0.tgz",
-      "integrity": "sha1-0GB4oUZM9WzbfqYk6h4TpxuIuAY="
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
+      "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
     },
     "@turf/meta": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-3.14.0.tgz",
-      "integrity": "sha1-jTBQwaD0S/QGpjO2vSjFEPe87ic="
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
+      "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
+      "requires": {
+        "@turf/helpers": "6.x"
+      }
     },
     "array-filter": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "real-changesets-parser",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "Convert JSONs returned by osm-adiff-parser to proper geojsons",
   "main": "index.js",
   "scripts": {
@@ -20,9 +20,9 @@
     "tape": "^5.0.1"
   },
   "dependencies": {
-    "@turf/bbox": "^3.13.0",
-    "@turf/bbox-polygon": "^3.13.0",
-    "@turf/helpers": "^3.13.0",
+    "@turf/bbox": "^6.0.1",
+    "@turf/bbox-polygon": "^6.0.1",
+    "@turf/helpers": "^6.1.4",
     "id-area-keys": "^2.17.3",
     "ramda": "^0.27.1"
   }


### PR DESCRIPTION
Some changesets were failing to load on OSMCha, example: https://osmcha.org/changesets/91547654, with that change, we make it work correctly: https://fervent-swirles-25dff7.netlify.app/#91547654

It also solves problems on `osm-adiff-compare`.